### PR TITLE
fix: handle undefined values in recharts tooltip formatter

### DIFF
--- a/nextjs-interface/src/app/ui/dashboard/DataGraph.tsx
+++ b/nextjs-interface/src/app/ui/dashboard/DataGraph.tsx
@@ -590,10 +590,12 @@ function DataGraphContent() {
                   padding={{ top: 50, bottom: 10 }}
                 />
                 <Tooltip
-                  formatter={(value: number, name: string) => [
-                    `${value.toFixed(2)}`,
-                    name,
-                  ]}
+                  formatter={(value, name) => {
+                    const numericValue =
+                      typeof value === "number" ? value : Number(value ?? 0);
+
+                    return [numericValue.toFixed(2), String(name)];
+                  }}
                   labelFormatter={(label: string) => {
                     const date = new Date(label);
                     return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
@@ -673,10 +675,12 @@ function DataGraphContent() {
                   padding={{ top: 50, bottom: 10 }}
                 />
                 <Tooltip
-                  formatter={(value: number, name: string) => [
-                    `${value.toFixed(2)}`,
-                    name,
-                  ]}
+                  formatter={(value, name) => {
+                    const numericValue =
+                      typeof value === "number" ? value : Number(value ?? 0);
+
+                    return [numericValue.toFixed(2), String(name)];
+                  }}
                   labelFormatter={(label: string) => {
                     const date = new Date(label);
                     return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;


### PR DESCRIPTION
## Overview

This PR fixes a TypeScript build error related to Recharts Tooltip formatter and improves data handling robustness.

## Changes

- Fix Tooltip `formatter` to handle `undefined` values safely
- Prevent crash during `next build`
- Ensure proper number formatting with fallback values

## Why

Recharts `value` can be `undefined`, but the formatter was strictly typed as `number`, causing a TypeScript error:

Type 'undefined' is not assignable to type 'number'

This fix ensures compatibility with Recharts typings and prevents runtime issues.

## Impact

- Fixes CI / Docker build failure
- Improves frontend stability when data is missing or incomplete
- No breaking changes

## Testing

- Build passes (`next build`)
- Charts render correctly
- Tooltip displays formatted values without crashing
